### PR TITLE
Spark 1.6.1

### DIFF
--- a/Procfile-engine
+++ b/Procfile-engine
@@ -1,1 +1,1 @@
-web: cd pio-engine/ && pio deploy --port $PORT --event-server-ip $PIO_EVENTSERVER_IP --event-server-port $PIO_EVENTSERVER_PORT --accesskey $ACCESS_KEY --driver-class-path /app/lib/postgresql_jdbc.jar
+web: cd pio-engine/ && pio deploy --port $PORT --event-server-ip $PIO_EVENTSERVER_IP --event-server-port $PIO_EVENTSERVER_PORT --accesskey $ACCESS_KEY -- --driver-class-path /app/lib/postgresql_jdbc.jar

--- a/Procfile-engine
+++ b/Procfile-engine
@@ -1,1 +1,1 @@
-web: cd pio-engine/ && pio deploy --port $PORT --event-server-ip $PIO_EVENTSERVER_IP --event-server-port $PIO_EVENTSERVER_PORT --accesskey $ACCESS_KEY
+web: cd pio-engine/ && pio deploy --port $PORT --event-server-ip $PIO_EVENTSERVER_IP --event-server-port $PIO_EVENTSERVER_PORT --accesskey $ACCESS_KEY --driver-class-path /app/lib/postgresql_jdbc.jar

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ This step will vary based on the engine. See the template's docs for instruction
 ### Train the model
 
 ```bash
-heroku run bash --size Performance-M
+heroku run bash --size Performance-L
 cd pio-engine
-pio train -- --driver-memory 2g
+pio train -- --driver-memory 12g  --driver-class-path /app/lib/postgresql_jdbc.jar
 
 # Once it completes…
 exit

--- a/README.md
+++ b/README.md
@@ -110,10 +110,21 @@ This step will vary based on the engine. See the template's docs for instruction
 ```bash
 heroku run bash --size Performance-L
 cd pio-engine
-pio train -- --driver-memory 12g  --driver-class-path /app/lib/postgresql_jdbc.jar
+pio train -- --driver-memory 12g --driver-class-path /app/lib/postgresql_jdbc.jar
 
 # Once it completes…
 exit
+
+# If this was the first training, revive the app from "crashed" state.
+heroku restart
 ```
 
 * We specify a larger, more expensive dyno size for training. Adjust the `--size` & `--driver-memory` flags to fit each other & your requirements.
+
+### Running commands
+
+`pio` commands that require DB access will need to have the driver specified as an argument (bug with PIO 0.9.5 + Spark 1.6.1):
+
+```bash
+pio {command} -- --driver-class-path /app/lib/postgresql_jdbc.jar
+```

--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,7 @@ set -u
 SPARK_VERSION=1.6.1
 PIO_VERSION=0.9.5
 PIO_BUILD=PredictionIO-${PIO_VERSION}
+POSTGRESQL_DRIVER=postgresql-9.4.1209.jar
 
 function error() {
   echo " !     $*" >&2
@@ -125,3 +126,7 @@ fi
 
 topic "Setting Spark version for compatibility with PredictionIO"
 echo "$SPARK_VERSION" > "$BUILD_DIR/.spark.version"
+
+topic "Install PostgreSQL database driver"
+mkdir -p "/app/lib"
+curl -s -L "https://marsikai.s3.amazonaws.com/$POSTGRESQL_DRIVER" > /app/lib/postgresql_jdbc.jar

--- a/bin/compile
+++ b/bin/compile
@@ -128,5 +128,5 @@ topic "Setting Spark version for compatibility with PredictionIO"
 echo "$SPARK_VERSION" > "$BUILD_DIR/.spark.version"
 
 topic "Install PostgreSQL database driver"
-mkdir -p "/app/lib"
-curl -s -L "https://marsikai.s3.amazonaws.com/$POSTGRESQL_DRIVER" > /app/lib/postgresql_jdbc.jar
+mkdir -p "${BUILD_DIR}/lib"
+curl -s -L "https://marsikai.s3.amazonaws.com/$POSTGRESQL_DRIVER" > "${BUILD_DIR}/lib/postgresql_jdbc.jar"

--- a/bin/compile
+++ b/bin/compile
@@ -9,7 +9,7 @@ set -u
 # Debug, echo every command
 #set -x
 
-SPARK_VERSION=1.4.1
+SPARK_VERSION=1.6.1
 PIO_VERSION=0.9.5
 PIO_BUILD=PredictionIO-${PIO_VERSION}
 

--- a/config/pio-env-12f.sh
+++ b/config/pio-env-12f.sh
@@ -11,8 +11,7 @@
 # Must match $spark_dist_dir in bin.compile
 SPARK_HOME=/app/spark-home
 
-POSTGRES_JDBC_DRIVER=$PIO_HOME/lib/postgresql-9.4-1204.jdbc41.jar
-MYSQL_JDBC_DRIVER=$PIO_HOME/lib/mysql-connector-java-5.1.37.jar
+POSTGRES_JDBC_DRIVER=$SPARK_HOME/lib/postgresql_jdbc.jar
 
 # ES_CONF_DIR: You must configure this if you have advanced configuration for
 #              your Elasticsearch setup.

--- a/config/pio-env-12f.sh
+++ b/config/pio-env-12f.sh
@@ -11,7 +11,7 @@
 # Must match $spark_dist_dir in bin.compile
 SPARK_HOME=/app/spark-home
 
-POSTGRES_JDBC_DRIVER=$SPARK_HOME/lib/postgresql_jdbc.jar
+POSTGRES_JDBC_DRIVER=/app/lib/postgresql_jdbc.jar
 
 # ES_CONF_DIR: You must configure this if you have advanced configuration for
 #              your Elasticsearch setup.


### PR DESCRIPTION
Upgrade to Spark 1.6.1, which requires a workaround for making the PostgreSQL JDBC driver loadable.